### PR TITLE
Agregar gestión de clientes con soporte offline

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,6 +11,7 @@ from auth import auth_bp, login_required, logout
 from blueprints.autenticacion_avanzada import autenticacion_avanzada_bp
 from blueprints.facturacion_arca import facturacion_arca_bp
 from blueprints.secuencia_numerica import secuencia_bp
+from blueprints.clientes import clientes_bp
 from connectors.d365_interface import run_crear_presupuesto_batch, run_obtener_presupuesto_d365, run_actualizar_presupuesto_d365, run_validar_cliente_existente, run_alta_cliente_d365
 from connectors.get_token import get_access_token_d365, get_access_token_d365_qa
 from db.database import obtener_datos_tienda_por_id, obtener_empleados_by_email, actualizar_last_store, obtener_contador_pdf, save_cart, get_cart
@@ -1358,6 +1359,7 @@ app.register_blueprint(auth_bp, url_prefix='/auth')
 app.register_blueprint(autenticacion_avanzada_bp, url_prefix='/autenticacion_avanzada')
 app.register_blueprint(facturacion_arca_bp, url_prefix='/modulo_facturacion_arca')
 app.register_blueprint(secuencia_bp, url_prefix='/api/secuencias')
+app.register_blueprint(clientes_bp, url_prefix='/clientes')
 
 # 🔹 Ejecutar la aplicación
 if __name__ == "__main__":

--- a/blueprints/clientes.py
+++ b/blueprints/clientes.py
@@ -1,0 +1,90 @@
+import re
+import logging
+from flask import Blueprint, request, render_template, redirect, url_for, flash
+from db.database import guardar_cliente, actualizar_cliente, buscar_cliente_por_cuit
+from connectors.sap_clientes import consultar_datos_impositivos, actualizar_datos_impositivos
+
+logger = logging.getLogger('clientes')
+clientes_bp = Blueprint('clientes', __name__)
+
+
+def validar_dni(dni: str) -> bool:
+    return bool(re.fullmatch(r"\d{7,8}", dni or ""))
+
+
+def validar_cuit(cuit: str) -> bool:
+    return bool(re.fullmatch(r"\d{11}", cuit or ""))
+
+
+@clientes_bp.route('/nuevo', methods=['GET', 'POST'])
+def nuevo_cliente():
+    if request.method == 'POST':
+        datos = {
+            'nombre': request.form.get('nombre'),
+            'dni': request.form.get('dni'),
+            'cuit': request.form.get('cuit'),
+            'direccion': request.form.get('direccion')
+        }
+
+        if not validar_dni(datos['dni']):
+            flash('DNI inválido', 'danger')
+            return render_template('clientes/form.html', cliente=datos)
+
+        if not validar_cuit(datos['cuit']):
+            flash('CUIT inválido', 'danger')
+            return render_template('clientes/form.html', cliente=datos)
+
+        if buscar_cliente_por_cuit(datos['cuit']):
+            flash('El cliente ya existe', 'warning')
+            return render_template('clientes/form.html', cliente=datos)
+
+        guardar_cliente(datos)
+        try:
+            actualizar_datos_impositivos(datos['cuit'], datos)
+        except Exception as exc:  # pragma: no cover - fallo externo
+            logger.warning('No se pudo sincronizar con SAP: %s', exc)
+        flash('Cliente guardado', 'success')
+        return redirect(url_for('clientes.nuevo_cliente'))
+
+    return render_template('clientes/form.html', cliente=None)
+
+
+@clientes_bp.route('/<cuit>/editar', methods=['GET', 'POST'])
+def editar_cliente(cuit):
+    cliente = buscar_cliente_por_cuit(cuit)
+    if not cliente:
+        flash('Cliente no encontrado', 'danger')
+        return redirect(url_for('clientes.nuevo_cliente'))
+
+    if request.method == 'POST':
+        datos = {
+            'nombre': request.form.get('nombre'),
+            'dni': request.form.get('dni'),
+            'cuit': request.form.get('cuit'),
+            'direccion': request.form.get('direccion')
+        }
+
+        if not validar_dni(datos['dni']):
+            flash('DNI inválido', 'danger')
+            return render_template('clientes/form.html', cliente=datos)
+
+        if not validar_cuit(datos['cuit']):
+            flash('CUIT inválido', 'danger')
+            return render_template('clientes/form.html', cliente=datos)
+
+        actualizar_cliente(cuit, datos)
+        try:
+            actualizar_datos_impositivos(datos['cuit'], datos)
+        except Exception as exc:  # pragma: no cover
+            logger.warning('No se pudo sincronizar con SAP: %s', exc)
+        flash('Cliente actualizado', 'success')
+        return redirect(url_for('clientes.editar_cliente', cuit=datos['cuit']))
+
+    try:
+        sap_info = consultar_datos_impositivos(cuit)
+        if sap_info:
+            cliente.update(sap_info)
+    except Exception as exc:  # pragma: no cover
+        logger.warning('No se pudo consultar SAP: %s', exc)
+
+    return render_template('clientes/form.html', cliente=cliente)

--- a/connectors/sap_clientes.py
+++ b/connectors/sap_clientes.py
@@ -1,0 +1,61 @@
+import requests
+import configparser
+import os
+import logging
+
+ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+CONFIG_PATH = os.path.join(os.path.dirname(ROOT_DIR), 'config.ini')
+
+config = configparser.ConfigParser()
+config.read(CONFIG_PATH)
+
+LOG_DIR = os.path.join(ROOT_DIR, 'logs')
+os.makedirs(LOG_DIR, exist_ok=True)
+LOG_FILE = os.path.join(LOG_DIR, 'sap_clientes.log')
+
+logging.basicConfig(
+    filename=LOG_FILE,
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S'
+)
+
+
+def _load_sap_config():
+    if 'sap' not in config:
+        raise KeyError("La sección 'sap' no se encuentra en config.ini")
+    return {
+        'base_url': config['sap'].get('base_url', ''),
+        'token': config['sap'].get('token', '')
+    }
+
+
+def consultar_datos_impositivos(cuit):
+    cfg = _load_sap_config()
+    url = f"{cfg['base_url'].rstrip('/')}/clientes/{cuit}"
+    headers = {'Authorization': f"Bearer {cfg['token']}"}
+    try:
+        response = requests.get(url, headers=headers, timeout=30)
+        response.raise_for_status()
+        logging.info('Consulta de datos impositivos SAP exitosa para %s', cuit)
+        return response.json()
+    except Exception as exc:
+        logging.error('Error consultando SAP para %s: %s', cuit, exc)
+        return None
+
+
+def actualizar_datos_impositivos(cuit, datos):
+    cfg = _load_sap_config()
+    url = f"{cfg['base_url'].rstrip('/')}/clientes/{cuit}"
+    headers = {
+        'Authorization': f"Bearer {cfg['token']}",
+        'Content-Type': 'application/json'
+    }
+    try:
+        response = requests.post(url, json=datos, headers=headers, timeout=30)
+        response.raise_for_status()
+        logging.info('Actualización de datos impositivos SAP exitosa para %s', cuit)
+        return True
+    except Exception as exc:
+        logging.error('Error actualizando SAP para %s: %s', cuit, exc)
+        return False

--- a/db/database.py
+++ b/db/database.py
@@ -2,6 +2,7 @@ import requests
 import configparser
 import os
 import logging
+import sqlite3
 
 # Obtén la ruta absoluta a la raíz del proyecto
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -94,3 +95,65 @@ def get_access_token_d365_qa():
     except requests.exceptions.RequestException as e:
         logging.info(f"Consulta token a D365 FALLO. {e}")
         return None
+
+DB_PATH = os.path.join(ROOT_DIR, 'clientes.db')
+
+
+def init_db():
+    conn = sqlite3.connect(DB_PATH)
+    cursor = conn.cursor()
+    cursor.execute(
+        '''CREATE TABLE IF NOT EXISTS clientes (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            nombre TEXT NOT NULL,
+            dni TEXT NOT NULL,
+            cuit TEXT UNIQUE NOT NULL,
+            direccion TEXT
+        )'''
+    )
+    conn.commit()
+    conn.close()
+
+
+def guardar_cliente(datos):
+    conn = sqlite3.connect(DB_PATH)
+    cursor = conn.cursor()
+    cursor.execute(
+        'INSERT INTO clientes (nombre, dni, cuit, direccion) VALUES (?,?,?,?)',
+        (datos['nombre'], datos['dni'], datos['cuit'], datos.get('direccion'))
+    )
+    conn.commit()
+    conn.close()
+
+
+def actualizar_cliente(cuit, datos):
+    conn = sqlite3.connect(DB_PATH)
+    cursor = conn.cursor()
+    cursor.execute(
+        'UPDATE clientes SET nombre=?, dni=?, cuit=?, direccion=? WHERE cuit=?',
+        (
+            datos['nombre'],
+            datos['dni'],
+            datos['cuit'],
+            datos.get('direccion'),
+            cuit,
+        )
+    )
+    conn.commit()
+    conn.close()
+
+
+def buscar_cliente_por_cuit(cuit):
+    conn = sqlite3.connect(DB_PATH)
+    cursor = conn.cursor()
+    cursor.execute('SELECT nombre, dni, cuit, direccion FROM clientes WHERE cuit=?', (cuit,))
+    row = cursor.fetchone()
+    conn.close()
+    if row:
+        return {
+            'nombre': row[0],
+            'dni': row[1],
+            'cuit': row[2],
+            'direccion': row[3]
+        }
+    return None

--- a/static/scripts/clientes_offline.js
+++ b/static/scripts/clientes_offline.js
@@ -1,0 +1,84 @@
+const DB_NAME = 'ClientesDB';
+const STORE_NAME = 'clientes_pendientes';
+let db;
+
+function openDB() {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, 1);
+    request.onupgradeneeded = event => {
+      const db = event.target.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: 'cuit' });
+      }
+    };
+    request.onsuccess = event => {
+      db = event.target.result;
+      resolve(db);
+    };
+    request.onerror = () => reject(request.error);
+  });
+}
+
+async function saveClienteOffline(cliente) {
+  if (!db) await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.objectStore(STORE_NAME).put(cliente);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+async function getClientesPendientes() {
+  if (!db) await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const req = tx.objectStore(STORE_NAME).getAll();
+    req.onsuccess = () => resolve(req.result || []);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function deleteCliente(cuit) {
+  if (!db) await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.objectStore(STORE_NAME).delete(cuit);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+async function syncClientes() {
+  if (!navigator.onLine) return;
+  const pendientes = await getClientesPendientes();
+  for (const cliente of pendientes) {
+    try {
+      const resp = await fetch('/clientes/nuevo', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams(cliente)
+      });
+      if (resp.ok) {
+        await deleteCliente(cliente.cuit);
+      }
+    } catch (err) {
+      console.warn('Sincronización pendiente', err);
+    }
+  }
+}
+
+window.addEventListener('online', syncClientes);
+
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('clienteForm');
+  if (!form) return;
+  form.addEventListener('submit', async ev => {
+    if (!navigator.onLine) {
+      ev.preventDefault();
+      const data = Object.fromEntries(new FormData(form));
+      await saveClienteOffline(data);
+      alert('Cliente almacenado offline y se sincronizará cuando haya conexión.');
+    }
+  });
+});

--- a/templates/clientes/form.html
+++ b/templates/clientes/form.html
@@ -1,0 +1,25 @@
+{% extends 'layout.html' %}
+{% block title %}Gestión de Clientes{% endblock %}
+{% block content %}
+<h2>{{ 'Editar Cliente' if cliente else 'Nuevo Cliente' }}</h2>
+<form id="clienteForm" method="post">
+  <div class="mb-3">
+    <label for="nombre" class="form-label">Nombre</label>
+    <input type="text" class="form-control" id="nombre" name="nombre" value="{{ cliente.nombre if cliente else '' }}" required>
+  </div>
+  <div class="mb-3">
+    <label for="dni" class="form-label">DNI</label>
+    <input type="text" class="form-control" id="dni" name="dni" value="{{ cliente.dni if cliente else '' }}" required>
+  </div>
+  <div class="mb-3">
+    <label for="cuit" class="form-label">CUIT</label>
+    <input type="text" class="form-control" id="cuit" name="cuit" value="{{ cliente.cuit if cliente else '' }}" required>
+  </div>
+  <div class="mb-3">
+    <label for="direccion" class="form-label">Dirección</label>
+    <input type="text" class="form-control" id="direccion" name="direccion" value="{{ cliente.direccion if cliente else '' }}">
+  </div>
+  <button type="submit" class="btn btn-primary">Guardar</button>
+</form>
+<script src="{{ url_for('static', filename='scripts/clientes_offline.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
## Resumen
- Añade blueprint de clientes con rutas de alta y edición, validación de DNI/CUIT y sincronización con SAP.
- Implementa conector `sap_clientes` para consultar/actualizar datos impositivos.
- Extiende capa de base de datos con funciones de CRUD de clientes y prevención de duplicados.
- Agrega formulario HTML y script IndexedDB para operar sin conexión.

## Pruebas
- `python -m py_compile blueprints/clientes.py connectors/sap_clientes.py db/database.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a60d8eb014832494194666640526b7