### PR TITLE
Enable caching and offline persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# MyPOS Deployment Guide
+
+## Servidor WSGI y balanceo de carga
+- Utilice `gunicorn` como servidor WSGI.
+- Ejecute con múltiples workers utilizando la configuración incluida (`gunicorn.conf.py`).
+- Despliegue detrás de un balanceador de carga en la nube (p.ej. Azure Load Balancer o Application Gateway) para distribuir el tráfico.
+
+## Pooling de conexiones y caché
+- El módulo `db/fabric.py` implementa pooling de conexiones hacia la base de datos de Fabric/Azure para reducir la latencia y reutilizar conexiones.
+- `app.py` utiliza Redis para almacenar en caché información de clientes y productos. Configure la variable de entorno `REDIS_URL` apuntando a un servicio administrado de Redis.
+
+## Persistencia offline
+- Se agregó un *service worker* (`static/service-worker.js`) y soporte en `offline.js` para guardar ventas en cola usando IndexedDB cuando no hay conexión. Al recuperar la conectividad, las ventas pendientes se sincronizan automáticamente.
+
+## Requisitos de infraestructura y monitoreo
+- Dimensionar la infraestructura para al menos **200 sesiones simultáneas**.
+- Escalar horizontalmente el número de instancias detrás del balanceador según sea necesario.
+- Monitorear uso de CPU, memoria, workers de Gunicorn y métricas de Redis.
+- Integrar herramientas de monitoreo como Azure Monitor/Application Insights para trazas y alertas.

--- a/app.py
+++ b/app.py
@@ -17,6 +17,7 @@ from db.database import obtener_datos_tienda_por_id, obtener_empleados_by_email,
 from functools import lru_cache
 from services.email_service import enviar_correo_fallo
 import os
+import io
 import datetime
 import pyarrow.parquet as pq
 import pyarrow as pa
@@ -26,11 +27,40 @@ import threading
 from datetime import timedelta, timezone
 import json
 import requests
+import redis
 from config import CACHE_FILE_PRODUCTOS, CACHE_FILE_STOCK, CACHE_FILE_CLIENTES, CACHE_FILE_EMPLEADOS, CACHE_FILE_ATRIBUTOS
 
 clientes_lock = threading.Lock()
 
 app = Flask(__name__, static_folder='static')
+
+# 🔹 Configuración de Redis para caché
+redis_client = redis.Redis.from_url(os.getenv('REDIS_URL', 'redis://localhost:6379/0'))
+
+
+def cache_get_json(key):
+    data = redis_client.get(key)
+    if data:
+        return json.loads(data)
+    return None
+
+
+def cache_set_json(key, value, ex=3600):
+    redis_client.set(key, json.dumps(value), ex=ex)
+
+
+def cache_get_table(key):
+    data = redis_client.get(key)
+    if data:
+        buffer = io.BytesIO(data)
+        return pq.read_table(buffer)
+    return None
+
+
+def cache_set_table(key, table, ex=3600):
+    buffer = io.BytesIO()
+    pq.write_table(table, buffer)
+    redis_client.set(key, buffer.getvalue(), ex=ex)
 
 # 🔹 Inicializar la base de datos
 init_db()
@@ -110,6 +140,10 @@ def actualizar_cache_clientes():
 
 def obtener_clientes_cache():
     """Obtiene los clientes desde el archivo Parquet en memoria."""
+    cached_clients = cache_get_json('clientes_cache')
+    if cached_clients:
+        return cached_clients
+
     if os.path.exists(CACHE_FILE_CLIENTES):
         mod_time = datetime.date.fromtimestamp(os.path.getmtime(CACHE_FILE_CLIENTES))
         if mod_time != datetime.date.today():
@@ -125,6 +159,7 @@ def obtener_clientes_cache():
             logger.error("No se pudo cargar la tabla de clientes desde el Parquet.")
             return []
         clients = [{col: table[col][i].as_py() for col in table.column_names} for i in range(len(table))]
+        cache_set_json('clientes_cache', clients, ex=86400)
         return clients
     except Exception as e:
         logger.error(f"Error al leer clientes desde Parquet después de actualización: {e}", exc_info=True)
@@ -132,6 +167,10 @@ def obtener_clientes_cache():
 
 def obtener_productos_cache():
     """Obtiene los productos desde el archivo Parquet en memoria."""
+    cached_table = cache_get_table('productos_cache')
+    if cached_table is not None:
+        return cached_table
+
     if os.path.exists(CACHE_FILE_PRODUCTOS):
         mod_time = datetime.date.fromtimestamp(os.path.getmtime(CACHE_FILE_PRODUCTOS))
         if mod_time != datetime.date.today():
@@ -146,6 +185,7 @@ def obtener_productos_cache():
         if table is None:
             logger.error("No se pudo cargar la tabla de productos desde el Parquet.")
             return None
+        cache_set_table('productos_cache', table, ex=86400)
         return table
     except Exception as e:
         logger.error(f"Error al leer productos desde Parquet: {e}", exc_info=True)

--- a/db/fabric.py
+++ b/db/fabric.py
@@ -4,6 +4,9 @@ import pyodbc
 import logging
 import asyncio
 import configparser
+import queue
+import threading
+from contextlib import contextmanager
 from db.database import agregar_atributos_masivo, agregar_stock_masivo, \
     agregar_grupos_cumplimiento_masivo, agregar_empleados_masivo, agregar_datos_tienda_masivo
 import requests
@@ -15,6 +18,9 @@ CONFIG_PATH = os.path.join(os.path.dirname(ROOT_DIR), 'config.ini')  # Config.in
 # Cargar la configuración
 config = configparser.ConfigParser()
 config.read(CONFIG_PATH)
+
+_pool_lock = threading.Lock()
+_connection_pool = queue.Queue(maxsize=10)
 
 def load_db_config():
     """
@@ -39,50 +45,50 @@ def load_db_config():
         "password_fabric": config['database'].get('password_fabric', ''),
     }
 
-def conectar_fabric_db():
-    """
-    Establishes a connection to the Fabric database using specified
-    authentication methods. The function utilizes multiple authentication
-    methods sequentially until a successful connection is made or all
-    methods fail. Log statements provide detailed information about
-    connection attempts and failures.
-
-    :raises pyodbc.Error: If the connection attempt fails for any of the
-        authentication methods.
-    :rtype: pyodbc.Connection or None
-    :return: A valid database connection object if successful;
-        otherwise, None if all authentication methods fail.
-    """
+def _create_connection():
     db_config = load_db_config()
     server = db_config["server_fabric"]
     database = db_config["database_fabric"]
     username = db_config["username_fabric"]
     password = db_config["password_fabric"]
+    conn_str = (
+        f"DRIVER={{ODBC Driver 17 for SQL Server}};"
+        f"SERVER={server};"
+        f"DATABASE={database};"
+        f"UID={username};"
+        f"PWD={password};"
+        "Authentication=ActiveDirectoryPassword;"
+    )
+    return pyodbc.connect(conn_str)
 
-    autenticaciones = [
-        {
-            "method": "aad_password",
-            "conn_str": (
-                f"DRIVER={{ODBC Driver 17 for SQL Server}};"
-                f"SERVER={server};"
-                f"DATABASE={database};"
-                f"UID={username};"
-                f"PWD={password};"
-                "Authentication=ActiveDirectoryPassword;"
-            )
-        }
-    ]
 
-    for auth in autenticaciones:
+def _get_connection():
+    with _pool_lock:
+        if not _connection_pool.empty():
+            return _connection_pool.get()
+    return _create_connection()
+
+
+def _release_connection(conn):
+    with _pool_lock:
         try:
-            conexion = pyodbc.connect(auth["conn_str"])
-            logging.info(f"Conexión exitosa usando el método de autenticación: {auth['method']}")
-            return conexion
-        except pyodbc.Error as e:
-            logging.warning(f"Intento de conexión fallido con el método: {auth['method']}. Error: {e}")
+            _connection_pool.put(conn, block=False)
+            return
+        except queue.Full:
+            pass
+    conn.close()
 
-    logging.error("No se pudo establecer conexión con ninguno de los métodos de autenticación.")
-    return None
+
+@contextmanager
+def conectar_fabric_db():
+    try:
+        conn = _get_connection()
+        yield conn
+    except pyodbc.Error as e:
+        logging.error(f"Error al conectar con Fabric: {e}")
+        raise
+    finally:
+        _release_connection(conn)
 
 def obtener_parquet_productos():
     url = 'https://fabricstorageeastus.blob.core.windows.net/fabric/Respondio/Productos_Buscador?sp=re&st=2025-03-31T17:42:39Z&se=2025-04-01T01:42:39Z&spr=https&sv=2024-11-04&sr=b&sig=Eewxv5qqA76g%2BSBvmoHQQJaYfuTLSW7KlMmSJsd0xVU%3D'
@@ -94,31 +100,21 @@ def obtener_atributos_fabric():
     Obtains attributes from the Fabric database and inserts them into another system in bulk.
     """
     query = "SELECT * FROM Atributos;"
-    conexion_fabric = conectar_fabric_db()
-    if not conexion_fabric:
-        logging.error("No se pudo conectar a la base de datos de Fabric.")
-        return 0
-
-    cursor_fabric = conexion_fabric.cursor()
-
     try:
-        cursor_fabric.execute(query)
-        atributos = cursor_fabric.fetchall()
+        with conectar_fabric_db() as conexion_fabric:
+            cursor_fabric = conexion_fabric.cursor()
+            cursor_fabric.execute(query)
+            atributos = cursor_fabric.fetchall()
 
-        if not atributos:
-            logging.info("No se encontraron atributos en Fabric.")
-            return 0
+            if not atributos:
+                logging.info("No se encontraron atributos en Fabric.")
+                return 0
 
-        total_insertados = agregar_atributos_masivo(atributos)
-        return total_insertados
-
+            total_insertados = agregar_atributos_masivo(atributos)
+            return total_insertados
     except Exception as e:
         logging.error(f"Error al obtener atributos de Fabric: {e}")
         return 0
-
-    finally:
-        conexion_fabric.close()
-        logging.info("Conexión con Fabric cerrada.")
 
 def obtener_stock_fabric():
     """
@@ -129,30 +125,21 @@ def obtener_stock_fabric():
     FROM DataStagingWarehouse.dbo.Stock_Buscador
     """
 
-    conexion_fabric = conectar_fabric_db()
-    if not conexion_fabric:
-        logging.error("No se pudo conectar a la base de datos de Fabric.")
-        return 0
-
     try:
-        cursor = conexion_fabric.cursor()
-        cursor.execute(query)
-        stock_data = cursor.fetchall()
+        with conectar_fabric_db() as conexion_fabric:
+            cursor = conexion_fabric.cursor()
+            cursor.execute(query)
+            stock_data = cursor.fetchall()
 
-        if not stock_data:
-            logging.info("No se encontraron datos de stock en Fabric.")
-            return 0
+            if not stock_data:
+                logging.info("No se encontraron datos de stock en Fabric.")
+                return 0
 
-        total_insertados = agregar_stock_masivo(stock_data)
-        return total_insertados
-
+            total_insertados = agregar_stock_masivo(stock_data)
+            return total_insertados
     except Exception as e:
         logging.error(f"Error al obtener stock de Fabric: {e}")
         return 0
-
-    finally:
-        conexion_fabric.close()
-        logging.info("Conexión con Fabric cerrada.")
 
 def obtener_grupos_cumplimiento_fabric():
     """
@@ -163,30 +150,21 @@ def obtener_grupos_cumplimiento_fabric():
     FROM DataStagingWarehouse.dbo.Grupos_Cumplimiento_Buscador
     """
 
-    conexion_fabric = conectar_fabric_db()
-    if not conexion_fabric:
-        logging.error("No se pudo conectar a la base de datos de Fabric.")
-        return 0
-
     try:
-        cursor = conexion_fabric.cursor()
-        cursor.execute(query)
-        grupos_data = cursor.fetchall()
+        with conectar_fabric_db() as conexion_fabric:
+            cursor = conexion_fabric.cursor()
+            cursor.execute(query)
+            grupos_data = cursor.fetchall()
 
-        if not grupos_data:
-            logging.info("No se encontraron datos de grupos de cumplimiento en Fabric.")
-            return 0
+            if not grupos_data:
+                logging.info("No se encontraron datos de grupos de cumplimiento en Fabric.")
+                return 0
 
-        total_insertados = agregar_grupos_cumplimiento_masivo(grupos_data)
-        return total_insertados
-
+            total_insertados = agregar_grupos_cumplimiento_masivo(grupos_data)
+            return total_insertados
     except Exception as e:
         logging.error(f"Error al obtener grupos de cumplimiento de Fabric: {e}")
         return 0
-
-    finally:
-        conexion_fabric.close()
-        logging.info("Conexión con Fabric cerrada.")
 
 def obtener_empleados_fabric():
     """
@@ -204,31 +182,21 @@ def obtener_empleados_fabric():
         END as Numero_SAP
     FROM [Entidades_Dynamics_365_Prod].[dbo].[Employees] Empleados
     """)
-    conexion_fabric = conectar_fabric_db()
-    if not conexion_fabric:
-        logging.error("No se pudo conectar a la base de datos de Fabric.")
-        return 0
-
-    cursor_fabric = conexion_fabric.cursor()
-
     try:
-        cursor_fabric.execute(query)
-        empleados = cursor_fabric.fetchall()
+        with conectar_fabric_db() as conexion_fabric:
+            cursor_fabric = conexion_fabric.cursor()
+            cursor_fabric.execute(query)
+            empleados = cursor_fabric.fetchall()
 
-        if not empleados:
-            logging.info("No se encontraron empleados en Fabric.")
-            return 0
+            if not empleados:
+                logging.info("No se encontraron empleados en Fabric.")
+                return 0
 
-        total_insertados = agregar_empleados_masivo(empleados)
-        return total_insertados
-
+            total_insertados = agregar_empleados_masivo(empleados)
+            return total_insertados
     except Exception as e:
         logging.error(f"Error al obtener empleados de Fabric: {e}")
         return 0
-
-    finally:
-        conexion_fabric.close()
-        logging.info("Conexión con Fabric cerrada.")
 
 def obtener_datos_tiendas():
     """
@@ -257,38 +225,28 @@ def obtener_datos_tiendas():
     AND IND2.inventsiteid IS NOT NULL;
     """
 
-    conexion_fabric = conectar_fabric_db()
-    if not conexion_fabric:
-        logging.error("No se pudo conectar a la base de datos de Fabric.")
-        raise ConnectionError("Error de conexión: No se pudo conectar a Fabric DB.")
-
     try:
-        cursor_fabric = conexion_fabric.cursor()
-        logging.info("Ejecutando consulta SQL en Fabric...")
-        cursor_fabric.execute(query)
-        logging.info("Consulta ejecutada con éxito.")
+        with conectar_fabric_db() as conexion_fabric:
+            cursor_fabric = conexion_fabric.cursor()
+            logging.info("Ejecutando consulta SQL en Fabric...")
+            cursor_fabric.execute(query)
+            logging.info("Consulta ejecutada con éxito.")
 
-        logging.info("Recuperando los datos de tiendas con fetchall()...")
-        productos = cursor_fabric.fetchall()
-        logging.info(f"Número de registros recuperados: {len(productos)}")
+            logging.info("Recuperando los datos de tiendas con fetchall()...")
+            productos = cursor_fabric.fetchall()
+            logging.info(f"Número de registros recuperados: {len(productos)}")
 
-        if not productos:
-            logging.info("No se encontraron datos en Fabric.")
-            return 0
+            if not productos:
+                logging.info("No se encontraron datos en Fabric.")
+                return 0
 
-        total_insertados = agregar_datos_tienda_masivo(productos)
-        logging.info(f"Total de datos de tiendas insertados: {total_insertados}")
+            total_insertados = agregar_datos_tienda_masivo(productos)
+            logging.info(f"Total de datos de tiendas insertados: {total_insertados}")
 
-        return total_insertados
-
+            return total_insertados
     except Exception as e:
         logging.error(f"Error al obtener datos de tienda de Fabric: {e}\n{traceback.format_exc()}")
         return 0
-
-    finally:
-        if conexion_fabric:
-            conexion_fabric.close()
-            logging.info("Conexión con Fabric cerrada.")
 
 async def obtener_datos_codigo_postal(codigo_postal):
     """Consulta Fabric para obtener datos de dirección basados en el código postal."""
@@ -314,36 +272,30 @@ async def obtener_datos_codigo_postal(codigo_postal):
         AND AD.[value.ZipCode] = ?
     """
 
-    conexion_fabric = conectar_fabric_db()
-    if not conexion_fabric:
-        logging.error("No se pudo conectar a Fabric.")
-        return None, "Error de conexión a Fabric"
-
     try:
-        cursor = conexion_fabric.cursor()
-        cursor.execute(query, (codigo_postal,))
-        resultados = cursor.fetchall()
-        if not resultados:
-            logging.info(f"No se encontraron datos para el código postal {codigo_postal}")
-            return [], None
-        datos = [
-            {
-                "AddressZipCode": row.AddressZipCode,
-                "AddressCountryRegionId": row.AddressCountryRegionId,
-                "AddressState": row.AddressState,
-                "AddressCounty": row.AddressCounty,
-                "AddressCity": row.AddressCity,
-                "CountyName": row.CountyName
-            } for row in resultados
-        ]
-        logging.info(f"Datos encontrados para código postal {codigo_postal}: {len(datos)} registros")
-        return datos, None
+        with conectar_fabric_db() as conexion_fabric:
+            cursor = conexion_fabric.cursor()
+            cursor.execute(query, (codigo_postal,))
+            resultados = cursor.fetchall()
+            if not resultados:
+                logging.info(f"No se encontraron datos para el código postal {codigo_postal}")
+                return [], None
+            datos = [
+                {
+                    "AddressZipCode": row.AddressZipCode,
+                    "AddressCountryRegionId": row.AddressCountryRegionId,
+                    "AddressState": row.AddressState,
+                    "AddressCounty": row.AddressCounty,
+                    "AddressCity": row.AddressCity,
+                    "CountyName": row.CountyName
+                } for row in resultados
+            ]
+            logging.info(f"Datos encontrados para código postal {codigo_postal}: {len(datos)} registros")
+            return datos, None
     except Exception as e:
         error = f"Error al consultar código postal en Fabric: {str(e)}"
         logging.error(error)
         return None, error
-    finally:
-        conexion_fabric.close()
 
 def run_obtener_datos_codigo_postal(codigo_postal):
     return asyncio.run(obtener_datos_codigo_postal(codigo_postal))

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,0 +1,4 @@
+import multiprocessing
+
+bind = "0.0.0.0:8000"
+workers = multiprocessing.cpu_count() * 2 + 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+Flask
+redis
+pyodbc
+requests
+apscheduler
+gunicorn

--- a/static/scripts/offline.js
+++ b/static/scripts/offline.js
@@ -1,0 +1,5 @@
+if ('serviceWorker' in navigator) {
+  window.addEventListener('online', () => {
+    navigator.serviceWorker.controller && navigator.serviceWorker.controller.postMessage('syncSales');
+  });
+}

--- a/static/service-worker.js
+++ b/static/service-worker.js
@@ -1,0 +1,64 @@
+const DB_NAME = 'OfflineSales';
+const STORE_NAME = 'salesQueue';
+
+function openDB() {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, 1);
+    request.onupgradeneeded = () => {
+      request.result.createObjectStore(STORE_NAME, { autoIncrement: true });
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+async function saveSale(data) {
+  const db = await openDB();
+  const tx = db.transaction(STORE_NAME, 'readwrite');
+  tx.objectStore(STORE_NAME).add(data);
+  return tx.complete;
+}
+
+async function sendQueuedSales() {
+  const db = await openDB();
+  const tx = db.transaction(STORE_NAME, 'readwrite');
+  const store = tx.objectStore(STORE_NAME);
+  const all = store.getAll();
+  return new Promise(resolve => {
+    all.onsuccess = async () => {
+      const items = all.result || [];
+      for (const sale of items) {
+        try {
+          await fetch('/ventas', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(sale)
+          });
+        } catch (_) {
+          // Si falla, mantener en cola
+          return resolve();
+        }
+      }
+      store.clear();
+      resolve();
+    };
+  });
+}
+
+self.addEventListener('fetch', event => {
+  if (event.request.method === 'POST' && event.request.url.includes('/ventas')) {
+    event.respondWith(
+      fetch(event.request.clone()).catch(async () => {
+        const data = await event.request.clone().json();
+        await saveSale(data);
+        return new Response(JSON.stringify({ offline: true }), { status: 202 });
+      })
+    );
+  }
+});
+
+self.addEventListener('message', event => {
+  if (event.data === 'syncSales') {
+    event.waitUntil(sendQueuedSales());
+  }
+});

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -458,6 +458,12 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.8.2/jspdf.plugin.autotable.min.js"></script>
 <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCEcZuoclTEV-n1maYIvTQ8C9LkWutbcus&libraries=places&callback=initMap" async defer></script>
 <script src="{{ url_for('static', filename='scripts/scripts.js') }}"></script>
+<script>
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('/static/service-worker.js');
+}
+</script>
+<script src="{{ url_for('static', filename='scripts/offline.js') }}"></script>
 {% block extra_scripts %}{% endblock %}
 <script>
   // Initialize Toasts

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,0 +1,4 @@
+from app import app
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
## Summary
- Add Redis caching and offline queue via service worker
- Introduce connection pooling for Fabric database
- Document deployment with Gunicorn workers and monitoring guidance

## Testing
- `python -m py_compile app.py db/fabric.py wsgi.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a60da8b5e08324a4eef6c70815c844