### PR TITLE
Add cash register blueprint and reporting views

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,6 +11,7 @@ from auth import auth_bp, login_required, logout
 from blueprints.autenticacion_avanzada import autenticacion_avanzada_bp
 from blueprints.facturacion_arca import facturacion_arca_bp
 from blueprints.secuencia_numerica import secuencia_bp
+from blueprints.caja import caja_bp
 from connectors.d365_interface import run_crear_presupuesto_batch, run_obtener_presupuesto_d365, run_actualizar_presupuesto_d365, run_validar_cliente_existente, run_alta_cliente_d365
 from connectors.get_token import get_access_token_d365, get_access_token_d365_qa
 from db.database import obtener_datos_tienda_por_id, obtener_empleados_by_email, actualizar_last_store, obtener_contador_pdf, save_cart, get_cart
@@ -1358,6 +1359,7 @@ app.register_blueprint(auth_bp, url_prefix='/auth')
 app.register_blueprint(autenticacion_avanzada_bp, url_prefix='/autenticacion_avanzada')
 app.register_blueprint(facturacion_arca_bp, url_prefix='/modulo_facturacion_arca')
 app.register_blueprint(secuencia_bp, url_prefix='/api/secuencias')
+app.register_blueprint(caja_bp, url_prefix='/caja')
 
 # 🔹 Ejecutar la aplicación
 if __name__ == "__main__":

--- a/blueprints/caja.py
+++ b/blueprints/caja.py
@@ -1,0 +1,195 @@
+from flask import Blueprint, request, jsonify, session, render_template, send_file
+from auth_module import login_required
+from db.database import (
+    obtener_facturas_emitidas,
+    obtener_saldos_por_vendedor,
+)
+from io import BytesIO
+
+caja_bp = Blueprint("caja", __name__)
+
+
+@caja_bp.route("/apertura", methods=["POST"])
+@login_required
+def apertura_caja():
+    """Abre la caja con un monto inicial opcional."""
+    monto_inicial = request.json.get("monto_inicial", 0.0)
+    session["caja_abierta"] = True
+    session["monto_inicial"] = monto_inicial
+    session.setdefault("movimientos_caja", [])
+    return jsonify({"message": "Caja abierta", "monto_inicial": monto_inicial})
+
+
+@caja_bp.route("/cierre", methods=["POST"])
+@login_required
+def cierre_caja():
+    """Cierra la caja y limpia la sesión."""
+    session.pop("caja_abierta", None)
+    session.pop("monto_inicial", None)
+    movimientos = session.pop("movimientos_caja", [])
+    return jsonify({"message": "Caja cerrada", "movimientos": movimientos})
+
+
+@caja_bp.route("/arqueo", methods=["POST"])
+@login_required
+def arqueo_caja():
+    """Registra un arqueo de caja."""
+    monto = request.json.get("monto", 0.0)
+    session.setdefault("arqueos", []).append(monto)
+    return jsonify({"message": "Arqueo registrado", "monto": monto})
+
+
+@caja_bp.route("/movimientos", methods=["POST"])
+@login_required
+def movimientos_caja():
+    """Registra un movimiento de caja (entrada/salida)."""
+    movimiento = request.json or {}
+    session.setdefault("movimientos_caja", []).append(movimiento)
+    return jsonify({"message": "Movimiento registrado", "movimiento": movimiento})
+
+
+# ---- Reportes ----
+
+@caja_bp.route("/reportes/facturas", methods=["GET"])
+@login_required
+def reportes_facturas():
+    """Vista con filtro de facturas emitidas."""
+    start = request.args.get("start_date")
+    end = request.args.get("end_date")
+    data = obtener_facturas_emitidas(start, end) if start and end else []
+    return render_template(
+        "reportes/facturas.html",
+        data=data,
+        start_date=start,
+        end_date=end,
+    )
+
+
+@caja_bp.route("/reportes/facturas/pdf", methods=["GET"])
+@login_required
+def reportes_facturas_pdf():
+    start = request.args.get("start_date")
+    end = request.args.get("end_date")
+    data = obtener_facturas_emitidas(start, end)
+    if not data:
+        return jsonify({"error": "No hay datos"}), 404
+    import pandas as pd
+    from reportlab.platypus import SimpleDocTemplate, Table, TableStyle
+    from reportlab.lib import colors
+
+    df = pd.DataFrame(data)
+    buffer = BytesIO()
+    doc = SimpleDocTemplate(buffer)
+    table_data = [df.columns.tolist()] + df.values.tolist()
+    table = Table(table_data)
+    table.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), colors.lightgrey),
+                ("GRID", (0, 0), (-1, -1), 1, colors.black),
+            ]
+        )
+    )
+    doc.build([table])
+    buffer.seek(0)
+    return send_file(
+        buffer,
+        as_attachment=True,
+        download_name="facturas.pdf",
+        mimetype="application/pdf",
+    )
+
+
+@caja_bp.route("/reportes/facturas/excel", methods=["GET"])
+@login_required
+def reportes_facturas_excel():
+    start = request.args.get("start_date")
+    end = request.args.get("end_date")
+    data = obtener_facturas_emitidas(start, end)
+    if not data:
+        return jsonify({"error": "No hay datos"}), 404
+    import pandas as pd
+
+    df = pd.DataFrame(data)
+    output = BytesIO()
+    with pd.ExcelWriter(output, engine="openpyxl") as writer:
+        df.to_excel(writer, index=False)
+    output.seek(0)
+    return send_file(
+        output,
+        as_attachment=True,
+        download_name="facturas.xlsx",
+        mimetype="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    )
+
+
+@caja_bp.route("/reportes/saldos", methods=["GET"])
+@login_required
+def reportes_saldos():
+    start = request.args.get("start_date")
+    end = request.args.get("end_date")
+    data = obtener_saldos_por_vendedor(start, end) if start and end else []
+    return render_template(
+        "reportes/saldos.html",
+        data=data,
+        start_date=start,
+        end_date=end,
+    )
+
+
+@caja_bp.route("/reportes/saldos/pdf", methods=["GET"])
+@login_required
+def reportes_saldos_pdf():
+    start = request.args.get("start_date")
+    end = request.args.get("end_date")
+    data = obtener_saldos_por_vendedor(start, end)
+    if not data:
+        return jsonify({"error": "No hay datos"}), 404
+    import pandas as pd
+    from reportlab.platypus import SimpleDocTemplate, Table, TableStyle
+    from reportlab.lib import colors
+
+    df = pd.DataFrame(data)
+    buffer = BytesIO()
+    doc = SimpleDocTemplate(buffer)
+    table_data = [df.columns.tolist()] + df.values.tolist()
+    table = Table(table_data)
+    table.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), colors.lightgrey),
+                ("GRID", (0, 0), (-1, -1), 1, colors.black),
+            ]
+        )
+    )
+    doc.build([table])
+    buffer.seek(0)
+    return send_file(
+        buffer,
+        as_attachment=True,
+        download_name="saldos.pdf",
+        mimetype="application/pdf",
+    )
+
+
+@caja_bp.route("/reportes/saldos/excel", methods=["GET"])
+@login_required
+def reportes_saldos_excel():
+    start = request.args.get("start_date")
+    end = request.args.get("end_date")
+    data = obtener_saldos_por_vendedor(start, end)
+    if not data:
+        return jsonify({"error": "No hay datos"}), 404
+    import pandas as pd
+
+    df = pd.DataFrame(data)
+    output = BytesIO()
+    with pd.ExcelWriter(output, engine="openpyxl") as writer:
+        df.to_excel(writer, index=False)
+    output.seek(0)
+    return send_file(
+        output,
+        as_attachment=True,
+        download_name="saldos.xlsx",
+        mimetype="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    )

--- a/db/database.py
+++ b/db/database.py
@@ -94,3 +94,29 @@ def get_access_token_d365_qa():
     except requests.exceptions.RequestException as e:
         logging.info(f"Consulta token a D365 FALLO. {e}")
         return None
+
+def obtener_facturas_emitidas(fecha_inicio, fecha_fin):
+    """Devuelve una lista simulada de facturas emitidas entre fechas."""
+    return [
+        {
+            "fecha": fecha_inicio,
+            "numero": "F0001",
+            "vendedor": "Juan",
+            "monto": 1000.0,
+        },
+        {
+            "fecha": fecha_fin,
+            "numero": "F0002",
+            "vendedor": "Ana",
+            "monto": 2000.0,
+        },
+    ]
+
+
+def obtener_saldos_por_vendedor(fecha_inicio, fecha_fin):
+    """Devuelve saldos simulados por vendedor en el rango de fechas."""
+    return [
+        {"vendedor": "Juan", "saldo": 500.0},
+        {"vendedor": "Ana", "saldo": 1500.0},
+    ]
+

--- a/templates/reportes/facturas.html
+++ b/templates/reportes/facturas.html
@@ -1,0 +1,34 @@
+{% extends 'layout.html' %}
+{% block title %}Reporte de Facturas{% endblock %}
+{% block content %}
+<h1>Facturas Emitidas</h1>
+<form method="get" class="row g-3 mb-3">
+  <div class="col-md-4">
+    <input type="date" name="start_date" value="{{ start_date }}" class="form-control" required>
+  </div>
+  <div class="col-md-4">
+    <input type="date" name="end_date" value="{{ end_date }}" class="form-control" required>
+  </div>
+  <div class="col-md-4">
+    <button type="submit" class="btn btn-primary">Filtrar</button>
+  </div>
+</form>
+{% if data %}
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>Fecha</th><th>Número</th><th>Vendedor</th><th>Monto</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for f in data %}
+    <tr>
+      <td>{{ f.fecha }}</td><td>{{ f.numero }}</td><td>{{ f.vendedor }}</td><td>{{ f.monto }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+<a class="btn btn-outline-secondary" href="{{ url_for('caja.reportes_facturas_pdf', start_date=start_date, end_date=end_date) }}">Descargar PDF</a>
+<a class="btn btn-outline-secondary" href="{{ url_for('caja.reportes_facturas_excel', start_date=start_date, end_date=end_date) }}">Descargar Excel</a>
+{% endif %}
+{% endblock %}

--- a/templates/reportes/saldos.html
+++ b/templates/reportes/saldos.html
@@ -1,0 +1,34 @@
+{% extends 'layout.html' %}
+{% block title %}Saldos por Vendedor{% endblock %}
+{% block content %}
+<h1>Saldos por Vendedor</h1>
+<form method="get" class="row g-3 mb-3">
+  <div class="col-md-4">
+    <input type="date" name="start_date" value="{{ start_date }}" class="form-control" required>
+  </div>
+  <div class="col-md-4">
+    <input type="date" name="end_date" value="{{ end_date }}" class="form-control" required>
+  </div>
+  <div class="col-md-4">
+    <button type="submit" class="btn btn-primary">Filtrar</button>
+  </div>
+</form>
+{% if data %}
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>Vendedor</th><th>Saldo</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for s in data %}
+    <tr>
+      <td>{{ s.vendedor }}</td><td>{{ s.saldo }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+<a class="btn btn-outline-secondary" href="{{ url_for('caja.reportes_saldos_pdf', start_date=start_date, end_date=end_date) }}">Descargar PDF</a>
+<a class="btn btn-outline-secondary" href="{{ url_for('caja.reportes_saldos_excel', start_date=start_date, end_date=end_date) }}">Descargar Excel</a>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- implement caja blueprint for cash opening/closing, movements and reports
- stub database queries for invoices and vendor balances
- add report templates with date filters and PDF/Excel export

## Testing
- `pip install pandas reportlab openpyxl` *(failed: Cannot connect to proxy)*
- `python -m py_compile blueprints/caja.py db/database.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a60da78860832492d4a9bd9a85610b