### PR TITLE
Add permissions and super key validation

### DIFF
--- a/static/scripts/cart.js
+++ b/static/scripts/cart.js
@@ -154,7 +154,9 @@ function addToCartConfirmed() {
             quantity: quantity,
             multiplo: currentProductToAdd.multiplo,
             unidadMedida: currentProductToAdd.unidadMedida,
-            available: true // Asumimos disponible inicialmente
+            available: true, // Asumimos disponible inicialmente
+            discount: 0,
+            surcharge: 0
         });
     }
     updateCartDisplay();
@@ -190,10 +192,12 @@ function updateCartDisplay() {
     let total = 0;
 
     if (cart.items.length === 0) {
-        cartTable.innerHTML = '<tr><td colspan="5" class="text-center text-muted">El carrito está vacío</td></tr>';
+        cartTable.innerHTML = '<tr><td colspan="8" class="text-center text-muted">El carrito está vacío</td></tr>';
     } else {
         cart.items.forEach(item => {
-            const itemTotal = item.price * item.quantity;
+            item.discount = item.discount || 0;
+            item.surcharge = item.surcharge || 0;
+            const itemTotal = (item.price * item.quantity) - item.discount + item.surcharge;
             total += itemTotal;
             const row = document.createElement('tr');
             row.innerHTML = `
@@ -203,6 +207,8 @@ function updateCartDisplay() {
                     <input type="number" class="form-control form-control-sm quantity-input" value="${item.quantity}" min="${item.multiplo}" step="${item.multiplo}" data-product-id="${item.productId}">
                 </td>
                 <td>$${formatearMoneda(item.price)}</td>
+                <td><input type="number" class="form-control form-control-sm discount-input" value="${item.discount}" min="0" step="0.01" data-product-id="${item.productId}"></td>
+                <td><input type="number" class="form-control form-control-sm surcharge-input" value="${item.surcharge}" min="0" step="0.01" data-product-id="${item.productId}"></td>
                 <td>$${formatearMoneda(itemTotal)}</td>
                 <td><button class="btn btn-danger btn-sm" onclick="removeFromCart('${item.productId}')">Eliminar</button></td>
             `;
@@ -217,6 +223,24 @@ function updateCartDisplay() {
                     updateCartDisplay();
                     saveCartToIndexedDB();
                 }
+            });
+
+            // Evento para descuento
+            const discountInput = row.querySelector('.discount-input');
+            discountInput.addEventListener('change', (e) => {
+                const newDiscount = parseFloat(e.target.value) || 0;
+                item.discount = newDiscount;
+                updateCartDisplay();
+                saveCartToIndexedDB();
+            });
+
+            // Evento para recargo
+            const surchargeInput = row.querySelector('.surcharge-input');
+            surchargeInput.addEventListener('change', (e) => {
+                const newSurcharge = parseFloat(e.target.value) || 0;
+                item.surcharge = newSurcharge;
+                updateCartDisplay();
+                saveCartToIndexedDB();
             });
         });
     }


### PR DESCRIPTION
## Summary
- store granular permissions in `usuarios_roles`
- require super key for sensitive actions
- allow discounts and surcharges per cart line

## Testing
- `python -m py_compile blueprints/autenticacion_avanzada.py`
- `node --check static/scripts/cart.js`


------
https://chatgpt.com/codex/tasks/task_e_68a60da5371c8324a3075b4451a89bde