### PR TITLE
Add budget tracking and product search index

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,11 +11,27 @@ from auth import auth_bp, login_required, logout
 from blueprints.autenticacion_avanzada import autenticacion_avanzada_bp
 from blueprints.facturacion_arca import facturacion_arca_bp
 from blueprints.secuencia_numerica import secuencia_bp
-from connectors.d365_interface import run_crear_presupuesto_batch, run_obtener_presupuesto_d365, run_actualizar_presupuesto_d365, run_validar_cliente_existente, run_alta_cliente_d365
+from connectors.d365_interface import (
+    run_crear_presupuesto_batch,
+    run_obtener_presupuesto_d365,
+    run_actualizar_presupuesto_d365,
+    run_validar_cliente_existente,
+    run_alta_cliente_d365,
+    guardar_numero_presupuesto,
+    obtener_numeros_presupuesto,
+)
 from connectors.get_token import get_access_token_d365, get_access_token_d365_qa
-from db.database import obtener_datos_tienda_por_id, obtener_empleados_by_email, actualizar_last_store, obtener_contador_pdf, save_cart, get_cart
+from db.database import (
+    obtener_datos_tienda_por_id,
+    obtener_empleados_by_email,
+    actualizar_last_store,
+    obtener_contador_pdf,
+    save_cart,
+    get_cart,
+)
 from functools import lru_cache
 from services.email_service import enviar_correo_fallo
+from services.search_service import indexar_productos, buscar_productos
 import os
 import datetime
 import pyarrow.parquet as pq
@@ -483,6 +499,13 @@ def productos():
     last_store = session.get('last_store', 'BA001GC')
     return render_template('index.html', stores=stores, last_store=last_store)
 
+
+@app.route('/presupuestos')
+@login_required
+def presupuestos_page():
+    """Página para gestionar presupuestos y carritos."""
+    return render_template('presupuestos.html')
+
 @app.route('/config/secuencias')
 @login_required
 def config_secuencias():
@@ -719,6 +742,7 @@ def create_quotation():
             return jsonify({"error": error}), 500
 
         logger.info(f"Presupuesto creado: {quotation_number}")
+        guardar_numero_presupuesto(quotation_number)
         return jsonify({"quotation_number": quotation_number}), 201
 
     except Exception as e:
@@ -822,6 +846,7 @@ def update_quotation(quotation_id):
             return jsonify({"error": error}), 500
 
         logger.info(f"Presupuesto {quotation_id} actualizado exitosamente")
+        guardar_numero_presupuesto(quotation_number)
         return jsonify({"quotation_number": quotation_number}), 200
 
     except Exception as e:
@@ -968,6 +993,40 @@ def api_productos_by_code():
         return jsonify(products), 200
     except Exception as e:
         logger.error(f"Error en búsqueda de producto por código: {e}", exc_info=True)
+        return jsonify({"error": str(e)}), 500
+
+
+@app.route('/api/index_products', methods=['POST'])
+@login_required
+def api_index_products():
+    """Indexa productos en MongoDB para búsquedas rápidas."""
+    try:
+        table = obtener_productos_cache()
+        if table is None:
+            return jsonify({"error": "No se pudo cargar los productos"}), 500
+        import pandas as pd
+        df = table.select(['Número de Producto', 'Nombre del Producto']).to_pandas()
+        productos = (
+            {"sku": row['Número de Producto'], "descripcion": row['Nombre del Producto']}
+            for _, row in df.iterrows()
+        )
+        count = indexar_productos(list(productos))
+        return jsonify({"indexed": count}), 200
+    except Exception as e:
+        logger.error(f"Error al indexar productos: {e}", exc_info=True)
+        return jsonify({"error": str(e)}), 500
+
+
+@app.route('/api/search_products_index')
+@login_required
+def api_search_products_index():
+    """Busca productos en el índice de Mongo por SKU o descripción."""
+    term = request.args.get('q', '').strip()
+    try:
+        results = buscar_productos(term)
+        return jsonify(results), 200
+    except Exception as e:
+        logger.error(f"Error al buscar productos en índice: {e}", exc_info=True)
         return jsonify({"error": str(e)}), 500
 
 @app.route('/api/save_local_quotation', methods=['POST'])
@@ -1319,6 +1378,18 @@ def get_user_cart():
         return jsonify(cart_data), 200
     except Exception as e:
         logger.error(f"Error al recuperar carrito: {e}", exc_info=True)
+        return jsonify({"error": str(e)}), 500
+
+
+@app.route('/api/quotation_numbers', methods=['GET'])
+@login_required
+def api_quotation_numbers():
+    """Devuelve los números de presupuesto almacenados localmente."""
+    try:
+        numeros = obtener_numeros_presupuesto()
+        return jsonify(numeros), 200
+    except Exception as e:
+        logger.error(f"Error al obtener números de presupuesto: {e}", exc_info=True)
         return jsonify({"error": str(e)}), 500
 
 @app.route('/api/clientes/search')

--- a/connectors/d365_interface.py
+++ b/connectors/d365_interface.py
@@ -29,6 +29,36 @@ logging.basicConfig(
     datefmt="%Y-%m-%d %H:%M:%S",
 )
 
+# Archivo local para persistir números de presupuesto
+PRESUPUESTOS_FILE = os.path.join(LOG_DIR, "presupuestos.json")
+
+
+def guardar_numero_presupuesto(numero):
+    """Guarda un número de presupuesto en un archivo JSON."""
+    try:
+        data = []
+        if os.path.exists(PRESUPUESTOS_FILE):
+            with open(PRESUPUESTOS_FILE, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        data.append({"numero": numero, "timestamp": datetime.utcnow().isoformat()})
+        with open(PRESUPUESTOS_FILE, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+        logging.info(f"Número de presupuesto {numero} guardado correctamente")
+    except Exception as e:
+        logging.error(f"Error al guardar número de presupuesto {numero}: {e}")
+
+
+def obtener_numeros_presupuesto():
+    """Devuelve la lista de números de presupuesto guardados."""
+    try:
+        if not os.path.exists(PRESUPUESTOS_FILE):
+            return []
+        with open(PRESUPUESTOS_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception as e:
+        logging.error(f"Error al obtener números de presupuesto: {e}")
+        return []
+
 def load_d365_config():
     if 'd365' not in config:
         raise KeyError("La sección 'd365' no se encuentra en config.ini")

--- a/services/search_service.py
+++ b/services/search_service.py
@@ -1,0 +1,65 @@
+import os
+import logging
+from typing import List, Dict
+
+# La dependencia pymongo puede no estar disponible en todos los entornos.
+# Se realiza la importación de forma opcional para evitar errores en tiempo de ejecución.
+try:
+    from pymongo import MongoClient, ASCENDING, TEXT
+except Exception:  # pragma: no cover - fallback en caso de ausencia
+    MongoClient = None
+    ASCENDING = TEXT = None
+
+logger = logging.getLogger(__name__)
+
+MONGO_URL = os.getenv("MONGO_URL", "mongodb://localhost:27017")
+MONGO_DB = os.getenv("MONGO_DB", "mypos")
+MONGO_COLLECTION = os.getenv("MONGO_COLLECTION", "productos")
+
+if MongoClient:
+    _client = MongoClient(MONGO_URL)
+    _db = _client[MONGO_DB]
+    _collection = _db[MONGO_COLLECTION]
+    # Ensure indexes for fast lookup
+    _collection.create_index([("sku", ASCENDING)], unique=True)
+    _collection.create_index([("descripcion", TEXT)])
+else:  # pragma: no cover - entorno sin MongoDB
+    _collection = None
+
+
+def indexar_productos(productos: List[Dict[str, str]]) -> int:
+    """Indexa una lista de productos en MongoDB.
+
+    Args:
+        productos: Lista de diccionarios con claves ``sku`` y ``descripcion``.
+    Returns:
+        Número de documentos indexados.
+    """
+    if not productos or _collection is None:
+        logger.warning("Colección de MongoDB no disponible o lista vacía")
+        return 0
+    operaciones = []
+    for prod in productos:
+        operaciones.append(
+            {
+                "update_one": {
+                    "filter": {"sku": prod.get("sku")},
+                    "update": {"$set": prod},
+                    "upsert": True,
+                }
+            }
+        )
+    if operaciones:
+        result = _collection.bulk_write(operaciones)
+        return result.upserted_count + result.modified_count
+    return 0
+
+
+def buscar_productos(termino: str) -> List[Dict[str, str]]:
+    """Busca productos por SKU exacto o por coincidencia en la descripción."""
+    if not termino or _collection is None:
+        return []
+    query = {"$or": [{"sku": termino}, {"$text": {"$search": termino}}]}
+    cursor = _collection.find(query, {"_id": 0})
+    return list(cursor)
+

--- a/templates/presupuestos.html
+++ b/templates/presupuestos.html
@@ -1,0 +1,79 @@
+{% extends 'layout.html' %}
+{% block title %}Presupuestos{% endblock %}
+{% block content %}
+<div class="container">
+  <h1 class="mb-4">Gestión de Presupuestos</h1>
+
+  <div class="mb-4">
+    <label for="searchTerm" class="form-label">Buscar producto por SKU o descripción</label>
+    <div class="input-group">
+      <input id="searchTerm" type="text" class="form-control" placeholder="SKU o descripción">
+      <button id="searchBtn" class="btn btn-primary" type="button">Buscar</button>
+    </div>
+    <ul id="searchResults" class="list-group mt-2"></ul>
+  </div>
+
+  <div class="mb-4">
+    <button id="saveCartBtn" class="btn btn-success me-2" type="button">Guardar Carrito</button>
+    <button id="restoreCartBtn" class="btn btn-secondary" type="button">Restaurar Carrito</button>
+  </div>
+
+  <div>
+    <h5>Números de presupuesto guardados</h5>
+    <ul id="quotationList" class="list-group"></ul>
+  </div>
+</div>
+
+<script>
+  async function cargarPresupuestos() {
+    try {
+      const res = await fetch('/api/quotation_numbers');
+      const data = await res.json();
+      const list = document.getElementById('quotationList');
+      list.innerHTML = '';
+      data.forEach(p => {
+        const li = document.createElement('li');
+        li.className = 'list-group-item';
+        li.textContent = p.numero;
+        list.appendChild(li);
+      });
+    } catch (err) {
+      console.error('Error cargando presupuestos:', err);
+    }
+  }
+
+  document.getElementById('searchBtn').addEventListener('click', async () => {
+    const term = document.getElementById('searchTerm').value;
+    const res = await fetch(`/api/search_products_index?q=${encodeURIComponent(term)}`);
+    const data = await res.json();
+    const list = document.getElementById('searchResults');
+    list.innerHTML = '';
+    data.forEach(p => {
+      const li = document.createElement('li');
+      li.className = 'list-group-item';
+      li.textContent = `${p.sku} - ${p.descripcion}`;
+      list.appendChild(li);
+    });
+  });
+
+  document.getElementById('saveCartBtn').addEventListener('click', async () => {
+    const cart = JSON.parse(localStorage.getItem('cart') || '{}');
+    const timestamp = new Date().toISOString();
+    await fetch('/api/save_user_cart', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: '{{ session.get('email') }}', cart, timestamp })
+    });
+    alert('Carrito guardado');
+  });
+
+  document.getElementById('restoreCartBtn').addEventListener('click', async () => {
+    const res = await fetch('/api/get_user_cart');
+    const data = await res.json();
+    localStorage.setItem('cart', JSON.stringify(data));
+    alert('Carrito restaurado');
+  });
+
+  cargarPresupuestos();
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- persist quotation numbers and expose them via API and UI
- add MongoDB-based product index and search endpoints
- create presupuesto page with controls to search, save and restore carts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a60d9f91bc8324842178c79f17210e