### PR TITLE
Soporte de pagos mixtos

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,6 +11,7 @@ from auth import auth_bp, login_required, logout
 from blueprints.autenticacion_avanzada import autenticacion_avanzada_bp
 from blueprints.facturacion_arca import facturacion_arca_bp
 from blueprints.secuencia_numerica import secuencia_bp
+from blueprints.pagos import pagos_bp
 from connectors.d365_interface import run_crear_presupuesto_batch, run_obtener_presupuesto_d365, run_actualizar_presupuesto_d365, run_validar_cliente_existente, run_alta_cliente_d365
 from connectors.get_token import get_access_token_d365, get_access_token_d365_qa
 from db.database import obtener_datos_tienda_por_id, obtener_empleados_by_email, actualizar_last_store, obtener_contador_pdf, save_cart, get_cart
@@ -1358,6 +1359,7 @@ app.register_blueprint(auth_bp, url_prefix='/auth')
 app.register_blueprint(autenticacion_avanzada_bp, url_prefix='/autenticacion_avanzada')
 app.register_blueprint(facturacion_arca_bp, url_prefix='/modulo_facturacion_arca')
 app.register_blueprint(secuencia_bp, url_prefix='/api/secuencias')
+app.register_blueprint(pagos_bp, url_prefix='/pagos')
 
 # 🔹 Ejecutar la aplicación
 if __name__ == "__main__":

--- a/blueprints/pagos.py
+++ b/blueprints/pagos.py
@@ -1,0 +1,69 @@
+import os
+import csv
+import requests
+from flask import Blueprint, request, jsonify, render_template
+from db.database import guardar_pago, actualizar_estado_operacion
+
+pagos_bp = Blueprint('pagos', __name__)
+
+BANK_API_URL = os.getenv('BANK_API_URL')
+
+
+def validar_transferencia(referencia: str, monto: float) -> bool:
+    """Valida una transferencia contra una API bancaria o archivo de conciliación.
+
+    Primero intenta consultar una API bancaria definida por la variable
+    de entorno ``BANK_API_URL``. Si no está configurada o la validación
+    falla, se consulta un archivo ``conciliaciones.csv`` almacenado en
+    la raíz del proyecto.
+    """
+    if monto <= 0:
+        return True
+
+    if BANK_API_URL and referencia:
+        try:
+            response = requests.get(f"{BANK_API_URL}/{referencia}", timeout=10)
+            if response.ok:
+                data = response.json()
+                return float(data.get('monto', 0)) == float(monto)
+        except requests.RequestException:
+            pass
+
+    conciliacion_path = os.path.join(os.path.dirname(__file__), '../conciliaciones.csv')
+    if os.path.exists(conciliacion_path) and referencia:
+        with open(conciliacion_path, newline='', encoding='utf-8') as csvfile:
+            reader = csv.DictReader(csvfile)
+            for row in reader:
+                try:
+                    if (row.get('referencia') == referencia and
+                            float(row.get('monto', 0)) == float(monto)):
+                        return True
+                except (TypeError, ValueError):
+                    continue
+    return False
+
+
+@pagos_bp.route('/registrar', methods=['POST'])
+def registrar_pago():
+    """Registra un pago mixto para una operación."""
+    data = request.get_json(silent=True) or request.form
+    operacion_id = data.get('operacion_id')
+    pagos = {
+        'efectivo': float(data.get('efectivo', 0) or 0),
+        'transferencia': float(data.get('transferencia', 0) or 0),
+        'tarjeta': float(data.get('tarjeta', 0) or 0),
+    }
+    referencia = data.get('referencia')
+
+    if pagos['transferencia'] and not validar_transferencia(referencia, pagos['transferencia']):
+        return jsonify({'error': 'Transferencia no válida'}), 400
+
+    guardar_pago(operacion_id, pagos)
+    actualizar_estado_operacion(operacion_id, 'pagado')
+    return jsonify({'status': 'ok'})
+
+
+@pagos_bp.route('/', methods=['GET'])
+def formulario_pagos():
+    """Muestra el formulario de pagos."""
+    return render_template('pagos.html')

--- a/db/database.py
+++ b/db/database.py
@@ -2,6 +2,7 @@ import requests
 import configparser
 import os
 import logging
+import json
 
 # Obtén la ruta absoluta a la raíz del proyecto
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -22,11 +23,10 @@ logging.basicConfig(
     datefmt="%Y-%m-%d %H:%M:%S",
 )
 
-def load_d365_config():
 
+def load_d365_config():
     if 'd365' not in config:
         raise KeyError("La sección 'd365' no se encuentra en config.ini")
-
     return {
         "resource": config['d365'].get('resource', ''),
         "token_client": config['d365'].get('token_client', ''),
@@ -40,7 +40,6 @@ def load_d365_config():
 
 
 def get_access_token_d365():
-
     d365_config = load_d365_config()
     client_id_prod = d365_config["client_id_prod"]
     client_secret_prod = d365_config["client_secret_prod"]
@@ -52,16 +51,13 @@ def get_access_token_d365():
         "client_secret": client_secret_prod,
         "resource": resource
     }
-
     try:
         response = requests.post(token_url, data=token_params, timeout=60)
-        response.raise_for_status()  # Verificar si hay errores en la respuesta
-
+        response.raise_for_status()
         token_data = response.json()
         access_token = token_data['access_token']
-        logging.info(f"Consulta token a D365 OK")
+        logging.info("Consulta token a D365 OK")
         return access_token
-
     except requests.exceptions.RequestException as e:
         logging.info(f"Consulta token a D365 FALLO. {e}")
         print("Error al obtener el token de acceso:", e)
@@ -69,7 +65,6 @@ def get_access_token_d365():
 
 
 def get_access_token_d365_qa():
-
     d365_config = load_d365_config()
     client_id_qa = d365_config["client_id_qa"]
     client_secret_qa = d365_config["client_secret_qa"]
@@ -81,16 +76,42 @@ def get_access_token_d365_qa():
         "client_secret": client_secret_qa,
         "resource": resource
     }
-
     try:
         response = requests.post(token_url, data=token_params, timeout=60)
-        response.raise_for_status()  # Verificar si hay errores en la respuesta
-
+        response.raise_for_status()
         token_data = response.json()
         access_token = token_data['access_token']
-        logging.info(f"Consulta token a D365 OK")
+        logging.info("Consulta token a D365 OK")
         return access_token
-
     except requests.exceptions.RequestException as e:
         logging.info(f"Consulta token a D365 FALLO. {e}")
         return None
+
+
+# ---- Gestión de pagos ----
+PAGOS_FILE = os.path.join(ROOT_DIR, "pagos.json")
+OPERACIONES_FILE = os.path.join(ROOT_DIR, "operaciones.json")
+
+
+def _read_json(path, default):
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return default
+
+
+def guardar_pago(operacion_id, pagos):
+    """Guarda el detalle de un pago en un archivo JSON."""
+    data = _read_json(PAGOS_FILE, [])
+    data.append({"operacion_id": operacion_id, **pagos})
+    with open(PAGOS_FILE, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
+def actualizar_estado_operacion(operacion_id, estado):
+    """Actualiza el estado de una operación en un archivo JSON."""
+    data = _read_json(OPERACIONES_FILE, {})
+    data[str(operacion_id)] = estado
+    with open(OPERACIONES_FILE, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)

--- a/static/scripts/scripts.js
+++ b/static/scripts/scripts.js
@@ -4854,3 +4854,28 @@ document.addEventListener('DOMContentLoaded', () => {
     updateFacturarButton(); // Inicializar estado del botón
     setInterval(updateFacturarButton, 1000); // Verificar cada segundo
 });
+
+function registerMixedPayment() {
+    const data = {
+        operacion_id: document.getElementById('operacionId')?.value || null,
+        efectivo: document.getElementById('cashCheck')?.checked ? parseFloat(document.getElementById('cashAmount').value || 0) : 0,
+        transferencia: document.getElementById('transferCheck')?.checked ? parseFloat(document.getElementById('transferAmount').value || 0) : 0,
+        tarjeta: document.getElementById('cardCheck')?.checked ? parseFloat(document.getElementById('cardAmount').value || 0) : 0,
+        referencia: document.getElementById('transferRef')?.value || ''
+    };
+    fetchWithAuth('/pagos/registrar', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data)
+    })
+    .then(r => r.json())
+    .then(resp => {
+        if (resp.status === 'ok') {
+            showToast('success', 'Pago registrado');
+        } else {
+            showToast('danger', resp.error || 'Error al registrar pago');
+        }
+    })
+    .catch(() => showToast('danger', 'Error de red al registrar pago'));
+}
+window.registerMixedPayment = registerMixedPayment;

--- a/templates/pagos.html
+++ b/templates/pagos.html
@@ -1,0 +1,40 @@
+{% extends 'layout.html' %}
+{% block title %}Pagos{% endblock %}
+{% block content %}
+<h2>Registrar Pago</h2>
+<form id="paymentForm" class="mt-3">
+  <input type="hidden" id="operacionId" name="operacion_id" value="">
+  <div class="mb-3">
+    <label class="form-check-label">
+      <input type="checkbox" class="form-check-input" id="cashCheck"> Efectivo
+    </label>
+    <input type="number" step="0.01" class="form-control mt-2" id="cashAmount" name="efectivo" placeholder="Monto en efectivo" disabled>
+  </div>
+  <div class="mb-3">
+    <label class="form-check-label">
+      <input type="checkbox" class="form-check-input" id="transferCheck"> Transferencia
+    </label>
+    <input type="text" class="form-control mt-2" id="transferRef" name="referencia" placeholder="Referencia" disabled>
+    <input type="number" step="0.01" class="form-control mt-2" id="transferAmount" name="transferencia" placeholder="Monto de transferencia" disabled>
+  </div>
+  <div class="mb-3">
+    <label class="form-check-label">
+      <input type="checkbox" class="form-check-input" id="cardCheck"> Tarjeta
+    </label>
+    <input type="number" step="0.01" class="form-control mt-2" id="cardAmount" name="tarjeta" placeholder="Monto con tarjeta" disabled>
+  </div>
+  <button type="button" class="btn btn-primary" onclick="registerMixedPayment()">Registrar Pago</button>
+</form>
+<script>
+  document.querySelectorAll('#paymentForm input[type="checkbox"]').forEach(cb => {
+    cb.addEventListener('change', () => {
+      const targetId = cb.id.replace('Check', 'Amount');
+      const amountField = document.getElementById(targetId);
+      if (amountField) amountField.disabled = !cb.checked;
+      if (cb.id === 'transferCheck') {
+        document.getElementById('transferRef').disabled = !cb.checked;
+      }
+    });
+  });
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add `pagos` blueprint with mixed payment routes and transfer validation
- Persist payment details and operation status
- Update templates and scripts for selecting multiple payment methods

## Testing
- `python -m py_compile blueprints/pagos.py db/database.py app.py`
- `pytest >/tmp/pytest.log ; cat /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68a60d9f7f888324b3fac18aa7323cd2