### PR TITLE
Add image URLs and cart line editing with Azure image storage

### DIFF
--- a/static/scripts/cart.js
+++ b/static/scripts/cart.js
@@ -202,8 +202,10 @@ function updateCartDisplay() {
                 <td>
                     <input type="number" class="form-control form-control-sm quantity-input" value="${item.quantity}" min="${item.multiplo}" step="${item.multiplo}" data-product-id="${item.productId}">
                 </td>
-                <td>$${formatearMoneda(item.price)}</td>
-                <td>$${formatearMoneda(itemTotal)}</td>
+                <td>
+                    <input type="number" class="form-control form-control-sm price-input" value="${item.price}" min="0" step="0.01" data-product-id="${item.productId}">
+                </td>
+                <td class="line-total">$${formatearMoneda(itemTotal)}</td>
                 <td><button class="btn btn-danger btn-sm" onclick="removeFromCart('${item.productId}')">Eliminar</button></td>
             `;
             cartTable.appendChild(row);
@@ -214,6 +216,17 @@ function updateCartDisplay() {
                 const newQuantity = validarCantidad(item.multiplo, parseFloat(e.target.value));
                 if (newQuantity !== item.quantity) {
                     item.quantity = newQuantity;
+                    updateCartDisplay();
+                    saveCartToIndexedDB();
+                }
+            });
+
+            // Agregar evento para actualizar precio
+            const priceInput = row.querySelector('.price-input');
+            priceInput.addEventListener('change', (e) => {
+                const newPrice = parseFloat(e.target.value);
+                if (!isNaN(newPrice) && newPrice !== item.price) {
+                    item.price = newPrice;
                     updateCartDisplay();
                     saveCartToIndexedDB();
                 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -145,7 +145,7 @@
 <div id="imageModal" class="image-modal">
   <div class="image-modal-content">
     <button class="close-modal" onclick="closeModal()">×</button>
-    <img id="modalImage" data-src="" alt="Producto">
+    <img id="modalImage" src="{{ url_for('serve_image', filename='default.jpg') }}" alt="Producto">
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- expose `imagen_url` for products and serve images from Azure Blob Storage through a protected route
- allow cart lines to edit quantity and price while updating totals
- load product images on the frontend using provided URLs and default fallback

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a60d9257608324b2d4845120a0df28