### PR TITLE
Fix LDAP error handler returning tuple

### DIFF
--- a/auth_module.py
+++ b/auth_module.py
@@ -101,7 +101,7 @@ def handle_ldap_error(error):
     mensaje = "No se pudo verificar las credenciales. Parece que no estás conectado a la VPN." if "WinError 10060" in str(error) else str(error)
     logger.error(f"Falló la conexión LDAP: {mensaje}")
     flash(mensaje, "danger")
-    return False, mensaje
+    return mensaje
 
 def get_access_token_graph():
     """Obtiene el token de autenticación para Microsoft Graph."""


### PR DESCRIPTION
## Summary
- ensure `handle_ldap_error` returns message string

## Testing
- `git ls-files -z -- '*.py' | xargs -0 python -m py_compile`


------
https://chatgpt.com/codex/tasks/task_e_68a608b021988324ad39ce5760c04951