### PR TITLE
Remove duplicated available flag in cart items

### DIFF
--- a/static/scripts/cart.js
+++ b/static/scripts/cart.js
@@ -158,13 +158,12 @@ function addToCartConfirmed() {
             multiplo: currentProductToAdd.multiplo,
             unidadMedida: currentProductToAdd.unidadMedida,
             iva: currentProductToAdd.iva,
-            available: true // Asumimos disponible inicialmente
             available: true, // Asumimos disponible inicialmente
             modalidad_entrega: null,
             lat: null,
             lng: null,
             costo_flete: 0,
-            id_linea: null
+            id_linea: null,
             discount: 0,
             surcharge: 0
         });


### PR DESCRIPTION
## Summary
- fix duplicate `available` property when adding items to cart

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a61f78b5388324bc1b5971954c85f7