### PR TITLE
Add payment simulator blueprint and cart integration

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,6 +15,7 @@ from blueprints.facturacion_arca import facturacion_arca_bp
 from blueprints.secuencia_numerica import secuencia_bp
 from blueprints.config_pos import config_pos_bp
 from blueprints.pagos import pagos_bp
+from blueprints.simulador import simulador_bp
 from connectors.d365_interface import (
     run_crear_presupuesto_batch,
     run_obtener_presupuesto_d365,
@@ -1665,6 +1666,7 @@ app.register_blueprint(pagos_bp, url_prefix='/pagos')
 app.register_blueprint(caja_bp, url_prefix='/caja')
 app.register_blueprint(pagos_bp, url_prefix='/pagos')
 app.register_blueprint(clientes_bp, url_prefix='/clientes')
+app.register_blueprint(simulador_bp, url_prefix='/pagos')
 
 # 🔹 Ejecutar la aplicación
 if __name__ == "__main__":

--- a/blueprints/simulador.py
+++ b/blueprints/simulador.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import Dict, Any
+
+from flask import Blueprint, request, render_template, jsonify
+
+# Blueprint para el simulador de pagos
+simulador_bp = Blueprint("simulador", __name__)
+
+# Reglas de financiación simuladas
+REGLAS: Dict[str, Dict[str, Any]] = {
+    "3_sin_interes": {"descripcion": "3 cuotas sin interés", "cuotas": 3, "coeficiente": 1.0},
+    "6_con_interes": {"descripcion": "6 cuotas (15% interés)", "cuotas": 6, "coeficiente": 1.15},
+}
+
+# Sucursales disponibles (placeholder)
+SUCURSALES = [
+    {"id": "BA001", "nombre": "Casa Central"},
+    {"id": "BA002", "nombre": "Sucursal Norte"},
+]
+
+
+def calcular_linea(monto: float, regla: Dict[str, Any]) -> Dict[str, float]:
+    """Calcula el total y el valor de cada cuota para una regla dada."""
+    coef = float(regla.get("coeficiente", 1))
+    cuotas = int(regla.get("cuotas", 1)) or 1
+    total = monto * coef
+    return {
+        "total": round(total, 2),
+        "cuota": round(total / cuotas, 2),
+        "cuotas": cuotas,
+    }
+
+
+@simulador_bp.route("/simulador", methods=["GET", "POST"])
+def simulador() -> str:
+    """Muestra el simulador de pagos o calcula una línea."""
+    total_carrito = request.args.get("total_carrito", type=float, default=0.0)
+    resultado = None
+
+    if request.method == "POST":
+        monto = request.form.get("monto", type=float, default=0.0)
+        regla_id = request.form.get("regla")
+        regla = REGLAS.get(regla_id)
+        if regla:
+            resultado = calcular_linea(monto, regla)
+        else:
+            return jsonify({"error": "Regla no encontrada"}), 400
+
+    return render_template(
+        "pagos/simulador.html",
+        reglas=REGLAS,
+        sucursales=SUCURSALES,
+        total_carrito=total_carrito,
+        resultado=resultado,
+    )

--- a/static/scripts/cart.js
+++ b/static/scripts/cart.js
@@ -270,6 +270,7 @@ function updateCartDisplay() {
         });
     }
 
+    cart.total = total;
     cartTotal.textContent = `$${formatearMoneda(total)}`;
     if (cart.client) {
         clientInfo.innerHTML = `
@@ -685,6 +686,19 @@ function loadQuotation(quotationId, type) {
             console.error('Error al cargar presupuesto:', error);
             showToast('danger', 'Error al cargar el presupuesto: ' + error.message);
         });
+}
+
+/***************************************
+ * Simulador de pagos
+ ***************************************/
+function openPaymentSimulator() {
+    try {
+        const total = cart.total || 0;
+        const url = `/pagos/simulador?total_carrito=${encodeURIComponent(total.toFixed(2))}`;
+        window.open(url, '_blank');
+    } catch (error) {
+        console.error('Error al abrir el simulador de pagos:', error);
+    }
 }
 
 /***************************************

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -166,6 +166,7 @@
       <button class="btn btn-outline-info rounded-pill" onclick="openClientSearchModal()" title="Buscar Cliente"><i class="bi bi-person"></i></button>
       <button class="btn btn-outline-secondary rounded-pill disabled" title="Crear Pedido (Próximamente)"><i class="bi bi-receipt"></i></button>
       <button class="btn btn-outline-secondary rounded-pill disabled" title="Definir Envío (Próximamente)"><i class="bi bi-truck"></i></button>
+      <button class="btn btn-outline-warning rounded-pill" onclick="openPaymentSimulator()" title="Simulador de pagos"><i class="bi bi-calculator"></i></button>
       <button id="facturarBtn" class="btn btn-outline-success rounded-pill" onclick="facturar()" title="Emitir Factura" disabled><i class="bi bi-receipt-cutout"></i> Facturar</button>
     </div>
     <div class="cart-content p-4 overflow-auto">

--- a/templates/pagos/simulador.html
+++ b/templates/pagos/simulador.html
@@ -1,0 +1,32 @@
+{% extends 'layout.html' %}
+{% block title %}Simulador de Pagos{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h2 class="mb-4">Simulador de Pagos</h2>
+  <form method="post" class="row g-3">
+    <div class="col-md-6">
+      <label for="monto" class="form-label">Monto</label>
+      <input type="number" step="0.01" class="form-control" id="monto" name="monto" value="{{ total_carrito }}">
+    </div>
+    <div class="col-md-6">
+      <label for="regla" class="form-label">Regla</label>
+      <select id="regla" name="regla" class="form-select">
+        {% for id, regla in reglas.items() %}
+          <option value="{{ id }}">{{ regla.descripcion }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="col-12">
+      <button type="submit" class="btn btn-primary">Calcular</button>
+    </div>
+  </form>
+  {% if resultado %}
+  <div class="mt-4">
+    <h4>Resultado</h4>
+    <p><strong>Total:</strong> ${{ '{:.2f}'.format(resultado.total) }}</p>
+    <p><strong>Cuotas:</strong> {{ resultado.cuotas }}</p>
+    <p><strong>Valor por cuota:</strong> ${{ '{:.2f}'.format(resultado.cuota) }}</p>
+  </div>
+  {% endif %}
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `simulador_bp` blueprint with payment rules and GET/POST route
- extract simulator HTML to `templates/pagos/simulador.html`
- wire simulator to cart overlay with new button and JS handler

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a61f77c08483249b750aa231691672