### PR TITLE
Add pymongo dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pyodbc
 requests
 apscheduler
 gunicorn
+pymongo>=4.0


### PR DESCRIPTION
## Summary
- Add pymongo version requirement to support MongoDB operations

## Testing
- `pip install -r requirements.txt` (fails: Could not find a version that satisfies the requirement pymongo>=4.0)
- `python app.py` (fails: ModuleNotFoundError: No module named 'ldap3')

------
https://chatgpt.com/codex/tasks/task_e_68a7329c1e708324be09130182811c09