### PR TITLE
Apply simulator theme globally across layouts

### DIFF
--- a/templates/layout_tablet.html
+++ b/templates/layout_tablet.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
     {% block extra_head %}{% endblock %}
 </head>
-<body class="tablet-layout">
+<body class="theme-sim tablet-layout">
 <nav class="navbar navbar-dark bg-dark fixed-top">
     <div class="container-fluid">
         <a class="navbar-brand" href="/">MyPOS</a>


### PR DESCRIPTION
## Summary
- Use simulator styling on tablet layout by adding `theme-sim` class

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a747bb6aec8324918d68177d71904d