### PR TITLE
Handle missing backend store list in filter initialization

### DIFF
--- a/static/scripts/scripts.js
+++ b/static/scripts/scripts.js
@@ -722,7 +722,9 @@ function initializeFilters(previousCategory = "", previousCoverage = "") {
   // Para el filtro de tiendas, se carga sólo en la carga inicial (usando la variable global backendStores)
   const storeFilterElement = document.getElementById("storeFilter");
   if (storeFilterElement && storeFilterElement.options.length === 0) {
-    const storeSet = new Set(backendStores);
+    // Aseguramos que backendStores sea un arreglo para evitar errores si es null o undefined
+    const backendStoresArray = Array.isArray(window.backendStores) ? window.backendStores : [];
+    const storeSet = new Set(backendStoresArray);
     populateFilter("storeFilter", storeSet, true);
   }
 }


### PR DESCRIPTION
## Summary
- Guard against undefined or null `backendStores` when initializing store filter

## Testing
- `node <<'NODE'` (initialize filters with no backend stores)
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a74ed1838c83248c1f989cbe3ede95