### PR TITLE
Add product lookup service for attribute route

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,7 @@
 from flask import Flask, render_template, redirect, url_for, session, jsonify, request, send_from_directory, flash, send_file
 from db.database import init_db, obtener_atributos, obtener_stores_from_parquet, obtener_stock, \
     obtener_grupos_cumplimiento, obtener_empleados, obtener_todos_atributos, guardar_token_d365, obtener_token_d365, \
-    obtener_producto_por_id, get_config_pos_by_ids, obtener_producto_por_id, buscar_productos_sap, obtener_producto_sap
+    get_config_pos_by_ids, buscar_productos_sap, obtener_producto_sap
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
 from apscheduler.events import EVENT_JOB_ERROR, EVENT_JOB_EXECUTED
@@ -36,6 +36,7 @@ from functools import lru_cache
 from services.email_service import enviar_correo_fallo
 from services.search_service import indexar_productos, buscar_productos
 from services.product_index import index_products, search_products
+from services.product_service import obtener_producto_por_id
 import os
 import io
 import datetime

--- a/services/product_service.py
+++ b/services/product_service.py
@@ -1,0 +1,44 @@
+import os
+import logging
+from typing import Any, Dict, Optional
+
+import pyarrow.parquet as pq
+import pyarrow.compute as pc
+
+from config import CACHE_FILE_PRODUCTOS
+
+logger = logging.getLogger(__name__)
+
+
+def obtener_producto_por_id(product_id: str | int) -> Optional[Dict[str, Any]]:
+    """Obtiene los datos de un producto por su ID desde el Parquet de productos.
+
+    Args:
+        product_id: Identificador del producto (código).
+
+    Returns:
+        Un diccionario con la información del producto o ``None`` si no se encuentra.
+    """
+    product_id = str(product_id)
+
+    if not os.path.exists(CACHE_FILE_PRODUCTOS):
+        logger.error("Archivo de productos no encontrado: %s", CACHE_FILE_PRODUCTOS)
+        return None
+
+    try:
+        table = pq.read_table(CACHE_FILE_PRODUCTOS)
+        column_mapping = {
+            "Número de Producto": "numero_producto",
+            "Nombre del Producto": "nombre_producto",
+        }
+        table = table.rename_columns([column_mapping.get(col, col) for col in table.column_names])
+        filtro = pc.equal(pc.field("numero_producto"), product_id)
+        resultado = table.filter(filtro)
+        if resultado.num_rows == 0:
+            return None
+        # Convertimos la primera fila a diccionario
+        record = resultado.slice(0, 1).to_pylist()[0]
+        return record
+    except Exception as e:  # pragma: no cover - logging
+        logger.error("Error al obtener producto por ID %s: %s", product_id, e, exc_info=True)
+        return None


### PR DESCRIPTION
## Summary
- Implement `obtener_producto_por_id` in new service using product Parquet cache
- Use new product lookup service in `app.py` for product attribute route

## Testing
- `pytest -q`
- `python - <<'PY'
from app import app
client = app.test_client()
client.get('/producto/atributos/123')
PY` *(fails: ModuleNotFoundError: No module named 'ldap3')*

------
https://chatgpt.com/codex/tasks/task_e_68a756666a5c8324a45bb0ad0c22531b